### PR TITLE
Place TARGET_FS_CONFIG_GEN passwd/group files in /vendor/etc

### DIFF
--- a/tools/fs_config/Android.mk
+++ b/tools/fs_config/Android.mk
@@ -276,6 +276,7 @@ include $(CLEAR_VARS)
 
 LOCAL_MODULE := passwd
 LOCAL_MODULE_CLASS := ETC
+LOCAL_VENDOR_MODULE := true
 
 include $(BUILD_SYSTEM)/base_rules.mk
 
@@ -294,6 +295,7 @@ include $(CLEAR_VARS)
 
 LOCAL_MODULE := group
 LOCAL_MODULE_CLASS := ETC
+LOCAL_VENDOR_MODULE := true
 
 include $(BUILD_SYSTEM)/base_rules.mk
 


### PR DESCRIPTION
These entries are vendor provided and belong on the /vendor partition.

Bug: 27999086
Test: end to end user/group check via config.fs and getpwnam, etc.
Change-Id: I9a5d56da594bf0d04de2b9ce7fd7d9a8151d4682