### PR TITLE
pathmap: Move RIL path mapping to core/config.mk

### DIFF
--- a/core/config.mk
+++ b/core/config.mk
@@ -186,10 +186,7 @@ FIND_LEAVES_EXCLUDES := $(addprefix --prune=, $(SCAN_EXCLUDE_DIRS) .repo .git)
 # General entries for project pathmap.  Any entries listed here should
 # be device and hardware independent.
 $(call project-set-path-variant,recovery,RECOVERY_VARIANT,bootable/recovery)
-ifeq ($(LINEAGE_BUILD),)
-# AOSP targets should use AOSP RIL
-$(call project-set-path,ril,hardware/ril)
-endif
+$(call project-set-path-variant,ril,TARGET_RIL_VARIANT,hardware/ril)
 
 -include vendor/extra/BoardConfigExtra.mk
 -include vendor/lineage/config/BoardConfigLineage.mk


### PR DESCRIPTION
* hardware/ril is a required project for any build. Since
  pathmap logic is available to any project building out of
  a Lineage checkout, RIL path mapping should be made
  available to all build types.

Change-Id: I45fd8771d0226caaf5ac05899fbbdb73a9cc8c01